### PR TITLE
Handle Windows path dividers

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,10 +90,10 @@ module.exports = (options) => {
               skip=true;
           })
           if(!skip){
-            if (fs.statSync(dirPath + "/" + file).isDirectory()) {
-              arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles)
+            if (fs.statSync(path.join(dirPath,file)).isDirectory()) {
+              arrayOfFiles = getAllFiles(path.join(dirPath,file), arrayOfFiles)
             } else {
-              arrayOfFiles.push(path.join(dirPath, "/", file))
+              arrayOfFiles.push(path.join(dirPath,file))
             }
           }
         })
@@ -105,7 +105,7 @@ module.exports = (options) => {
       var shortlists=[];
       all_files.forEach(function(file){
         // skip files in assets folder
-        if(file.indexOf('/assets/')>-1)
+        if(file.indexOf(path.sep + 'assets' + path.sep)>-1)
           return;
         // use this for debugging
         // if(match[1]=='CSS')
@@ -113,7 +113,7 @@ module.exports = (options) => {
 
         // if file name contains the obsidian string somewhere
         if(file.indexOf(match[1])>-1){
-          href=file.split(process.cwd())[1].split('.md')[0];
+          href=file.split(process.cwd())[1].split('.md')[0].replaceAll(path.sep, '/');
           // the value before it should be a slash. 
           // e.g.
           // '/notes/CSS', '/notes/Device size specific CSS'


### PR DESCRIPTION
The current implementation assumes unix/mac `/` path separators, which neatly maps to URLs. However when running on Windows as the path separators are `\` each the items will not be added to the shortlisted hrefs due to [index.js:122](https://github.com/notleigh/markdown-it-obsidian/blob/20cb28cac1cb290037e6d5e58df922a51ce02472/index.js#L122):

```
          if(href[i-1]=='/')
            shortlists.push(href);
```

Which results in no pages being found when resolving Obsidian style `[[internal-links]]`.

This change swaps out `path.sep` characters with `/` when converting the file path to a href to allow the shortlisted href check to pass as expected. It also uses `path.join` & `path.sep` to attempt to keep Windows behaviour consistent with other OS path handling.